### PR TITLE
add a new struct of ServiceClient1 which can substitute the original 'ServiceClient' of gophercloud

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -221,6 +221,65 @@ func v3auth(client *gophercloud.ProviderClient, endpoint string, opts tokens3.Au
 	return nil
 }
 
+func GetProjectId(client *gophercloud.ProviderClient) (string, error) {
+	versions := []*utils.Version{
+		{ID: v2, Priority: 20, Suffix: "/v2.0/"},
+		{ID: v3, Priority: 30, Suffix: "/v3/"},
+	}
+
+	chosen, endpoint, err := utils.ChooseVersion(client, versions)
+	if err != nil {
+		return "", err
+	}
+
+	switch chosen.ID {
+	case v2:
+		return getV2ProjectId(client, endpoint)
+	case v3:
+		return getV3ProjectId(client, endpoint)
+	default:
+		return "", fmt.Errorf("Unrecognized identity version: %s", chosen.ID)
+	}
+}
+
+func getV2ProjectId(client *gophercloud.ProviderClient, endpoint string) (string, error) {
+	v2Client, err := NewIdentityV2(client, gophercloud.EndpointOpts{})
+	if err != nil {
+		return "", err
+	}
+
+	if endpoint != "" {
+		v2Client.Endpoint = endpoint
+	}
+
+	result := tokens2.Get(v2Client, client.TokenID)
+	token, err := result.ExtractToken()
+	if err != nil {
+		return "", err
+	}
+
+	return token.Tenant.ID, nil
+}
+
+func getV3ProjectId(client *gophercloud.ProviderClient, endpoint string) (string, error) {
+	v3Client, err := NewIdentityV3(client, gophercloud.EndpointOpts{})
+	if err != nil {
+		return "", err
+	}
+
+	if endpoint != "" {
+		v3Client.Endpoint = endpoint
+	}
+
+	result := tokens3.Get(v3Client, client.TokenID)
+	project, err := result.ExtractProject()
+	if err != nil {
+		return "", err
+	}
+
+	return project.ID, nil
+}
+
 // NewIdentityV2 creates a ServiceClient that may be used to interact with the
 // v2 identity service.
 func NewIdentityV2(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts) (*gophercloud.ServiceClient, error) {
@@ -280,6 +339,23 @@ func initClientOpts(client *gophercloud.ProviderClient, eo gophercloud.EndpointO
 	sc.ProviderClient = client
 	sc.Endpoint = url
 	sc.Type = clientType
+	return sc, nil
+}
+
+func initClientOpts1(client *gophercloud.ProviderClient, eo gophercloud.EndpointOpts, clientType string) (*gophercloud.ServiceClient1, error) {
+	pid, e := GetProjectId(client)
+	if e != nil {
+		return nil, e
+	}
+
+	c, e := initClientOpts(client, eo, clientType)
+	if e != nil {
+		return nil, e
+	}
+
+	sc := new(gophercloud.ServiceClient1)
+	sc.ServiceClient = c
+	sc.ProjectID = pid
 	return sc, nil
 }
 

--- a/vendor/github.com/gophercloud/gophercloud/service_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/service_client.go
@@ -128,3 +128,11 @@ func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 		opts.MoreHeaders["OpenStack-API-Version"] = client.Type + " " + client.Microversion
 	}
 }
+
+type ServiceClient1 struct {
+	// ServiceClient is a reference to the ServiceClient.
+	*ServiceClient
+
+	// ProjectID is the ID of project to which User is authorized.
+	ProjectID string
+}


### PR DESCRIPTION
At present, It can get the 'project id' from 'ServiceClient' of gophercloud through the member of 'ProjectID' of 'ProviderClient', but it is not a correct way. Because 'ProviderClient.ProjectID' is a new member I added before, and it was not allowed to revise the 'ProviderClient'. It should use 'ServiceClient1' instead of 'ServiceClient' when the url of resource needs a parameter of 'project id'.  'ProviderClient.ProjectID' will be removed soon.