### PR TITLE
Change to use a generic pipeline to trigger job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,4 @@
 - project:
-    name: huawei-clouds/terraform-provider-telefonicaopencloud
-    check-telefonica:
+    check-generic-cloud:
       jobs:
         - terraform-provider-telefonicaopencloud-acceptance-test-telefonica


### PR DESCRIPTION
- Change to use generic pipeline to trigger job, after this, use a
  'recheck' than previous 'recheck telefonica' comment under PRs to
  trigger jobs.
- Remove the project name in the .zuul.yaml, it doesn't need anymore with
  the new version of zuul

Related with: # theopenlab/project-config/issues/8